### PR TITLE
Fix: 若 ListenPacket 的 callback 函数使用 @utils.thread_func, 则这个数据包将无法继续向下传递到其他插件. 

### DIFF
--- a/tooldelta/internal/packet_handler.py
+++ b/tooldelta/internal/packet_handler.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 from collections.abc import Callable
 
 from ..mc_bytes_packet.base_bytes_packet import BaseBytesPacket
@@ -14,9 +14,12 @@ INTERNAL_LISTEN_PACKETS: set[PacketIDS] = {
     PacketIDS.UpdateAbilities,
 }
 
-DictPacketListener = Callable[[dict], bool]
-BytesPacketListener = Callable[[BaseBytesPacket], bool]
+class Booleanable(Protocol):
+    def __bool__(self) -> bool:
+        return bool(self)
 
+DictPacketListener = Callable[[dict], Booleanable]
+BytesPacketListener = Callable[[BaseBytesPacket], Booleanable]
 
 class PacketHandler:
     def __init__(self, frame: "ToolDelta"):

--- a/tooldelta/plugin_load/classic_plugin/event_cbs.py
+++ b/tooldelta/plugin_load/classic_plugin/event_cbs.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, TypeVar
 from collections.abc import Callable
 
 from ...mc_bytes_packet.base_bytes_packet import BaseBytesPacket
-from ...utils import fmts, ToolDeltaThread
+from ...utils import fmts
 from ...constants import PacketIDS
 from ...internal.types import Player, Chat, InternalBroadcast, FrameExit
 from ..basic import ON_ERROR_CB
@@ -180,9 +180,8 @@ def execute_dict_packet_funcs(pktID: PacketIDS, pkt: dict, onerr: ON_ERROR_CB) -
     if d:
         try:
             for func in d:
-                res = func(pkt)
-                if res and (not isinstance(res, ToolDeltaThread)):
-                    return True
+                if res := func(pkt) is True:
+                    return res
         except Exception as err:
             onerr("插件方法:" + func.__name__, err)
     return False
@@ -204,9 +203,8 @@ def execute_bytes_packet_funcs(
     if d:
         try:
             for func in d:
-                res = func(pkt)
-                if res:
-                    return True
+                if res := func(pkt) is True:
+                    return res
         except Exception as err:
             onerr("插件方法:" + func.__name__, err)
     return False

--- a/tooldelta/plugin_load/classic_plugin/event_cbs.py
+++ b/tooldelta/plugin_load/classic_plugin/event_cbs.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, TypeVar
 from collections.abc import Callable
 
 from ...mc_bytes_packet.base_bytes_packet import BaseBytesPacket
-from ...utils import fmts
+from ...utils import fmts, ToolDeltaThread
 from ...constants import PacketIDS
 from ...internal.types import Player, Chat, InternalBroadcast, FrameExit
 from ..basic import ON_ERROR_CB
@@ -181,7 +181,7 @@ def execute_dict_packet_funcs(pktID: PacketIDS, pkt: dict, onerr: ON_ERROR_CB) -
         try:
             for func in d:
                 res = func(pkt)
-                if res:
+                if res and (not isinstance(res, ToolDeltaThread)):
                     return True
         except Exception as err:
             onerr("插件方法:" + func.__name__, err)

--- a/tooldelta/utils/tooldelta_thread.py
+++ b/tooldelta/utils/tooldelta_thread.py
@@ -54,6 +54,9 @@ class ToolDeltaThread(threading.Thread, Generic[PT, RT]):
         self._stop_event = threading.Event()
         self.start()
 
+    def __bool__(self) -> bool:
+        return True
+
     def run(self) -> None:
         """线程运行方法"""
         threads_list.append(self)


### PR DESCRIPTION
(比如 前置_玩家XUID获取)